### PR TITLE
Update glissas_retriever.txt

### DIFF
--- a/forge-gui/res/cardsfolder/g/ghostfire.txt
+++ b/forge-gui/res/cardsfolder/g/ghostfire.txt
@@ -2,5 +2,5 @@ Name:Ghostfire
 ManaCost:2 R
 Types:Instant
 A:SP$ DealDamage | Cost$ 2 R | ValidTgts$ Any | NumDmg$ 3 | SpellDescription$ CARDNAME deals 3 damage to any target.
-Colors:colorless
+S:Mode$ Continuous | EffectZone$ All | Affected$ Card.Self | CharacteristicDefining$ True | SetColor$ Colorless | Description$ CARDNAME is colorless.
 Oracle:Ghostfire is colorless.\nGhostfire deals 3 damage to any target.

--- a/forge-gui/res/cardsfolder/g/glissas_retriever.txt
+++ b/forge-gui/res/cardsfolder/g/glissas_retriever.txt
@@ -5,7 +5,7 @@ PT:6/6
 K:Haste
 K:Toxic:3
 S:Mode$ CantBlockBy | ValidAttacker$ Card.Self | ValidBlocker$ Creature.powerLE2 | Description$ CARDNAME can't be blocked by creatures with power 2 or less.
-T:Mode$ ChangesZone | Origin$ Any | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ Corrupted — When CARDNAME dies, exile it. When you do, return up to X target cards from your graveyard to your hand, where X is the number of opponents who have three or more poison counters.
+T:Mode$ ChangesZone | Origin$ Battlefield | Destination$ Graveyard | ValidCard$ Card.Self | Execute$ TrigExile | TriggerDescription$ Corrupted — When CARDNAME dies, exile it. When you do, return up to X target cards from your graveyard to your hand, where X is the number of opponents who have three or more poison counters.
 SVar:TrigExile:DB$ ChangeZone | Hidden$ True | Origin$ All | Destination$ Exile | Defined$ TriggeredCard | SubAbility$ DBImmediateTrigger
 SVar:DBImmediateTrigger:DB$ ImmediateTrigger | Execute$ TrigChangeZone | TriggerDescription$ When you do, return up to X target cards from your graveyard to your hand, where X is the number of opponents who have three or more poison counters.
 SVar:TrigChangeZone:DB$ ChangeZone | TargetMin$ 0 | TargetMax$ X | ValidTgts$ Card.YouOwn | TgtPrompt$ Select X target cards in your graveyard | Origin$ Graveyard | Destination$ Hand


### PR DESCRIPTION
Fixes Glissa's Retriever death trigger currently being treated as a put-ino-a-graveyard-from-anywhere trigger (and thus firing on being milled, discarded, etc)